### PR TITLE
[VDC-5151] IONOS Java SDK - Security Bugs Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@
 *.jar
 *.war
 *.ear
+*.iml
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
-/target/
-/.idea/
-/profitbricks-sdk-java.iml
+target/
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.5.3</version>
+            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.4.1.2</version>
+            <version>2.9.9</version>
             <type>jar</type>
         </dependency>
         <dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.4</version>
+            <version>4.5.8</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
1. Fix security alers as per GitHub recomendation
As per [github documentation](https://help.github.com/en/articles/about-security-alerts-for-vulnerable-dependencies) the security alerts for vulnerable dependencies reported by GitHub might be validated only for the master branch. You can't check those against a feature branch. In order to validate the changes I've made you can check GitHub suggestions from those alerts.

2. Update .gitignore file