### PR TITLE
[VDC-5170] IONOS Java SDK - Fix failing test for public API v4

### DIFF
--- a/src/test/java/com/profitbricks/rest/test/ResourceTest.java
+++ b/src/test/java/com/profitbricks/rest/test/ResourceTest.java
@@ -44,7 +44,7 @@ public class ResourceTest {
         waitTillProvisioned(datacenter.getRequestId());
 
         Volume volume = VolumeResource.getVolume();
-        volume.getProperties().setImage(VolumeTest.getImageId()); //"Ubuntu-15.04-server-2015-07-01"
+        volume.getProperties().setImage(VolumeTest.getImageId());
 
         Volume newVolume = profitbricksApi.getVolume().createVolume(dataCenterId, volume);
         assertNotNull(newVolume);

--- a/src/test/java/com/profitbricks/rest/test/SnapshotTest.java
+++ b/src/test/java/com/profitbricks/rest/test/SnapshotTest.java
@@ -77,7 +77,7 @@ public class SnapshotTest {
     public static String getImageId() throws RestClientException, IOException {
         Images images = profitbricksApi.getImage().getAllImages();
         for (Image image : images.getItems()) {
-            if (image.getProperties().getName().toLowerCase().contains("ubuntu-16".toLowerCase()) && image.getProperties().getLocation().equals("us/las")
+            if (image.getProperties().getName().toLowerCase().contains("ubuntu".toLowerCase()) && image.getProperties().getLocation().equals("us/las")
                     && image.getProperties().getIsPublic() && image.getProperties().getImageType().equals("HDD")) {
                 return image.getId();
             }

--- a/src/test/java/com/profitbricks/rest/test/VolumeTest.java
+++ b/src/test/java/com/profitbricks/rest/test/VolumeTest.java
@@ -72,8 +72,6 @@ public class VolumeTest {
     public static void setUp() throws RestClientException, IOException, InterruptedException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException {
         profitbricksApi.setCredentials(System.getenv("PROFITBRICKS_USERNAME"), System.getenv("PROFITBRICKS_PASSWORD"));
 
-        String imageId = getImageId();
-
         DataCenter newDatacenter = profitbricksApi.getDataCenter().createDataCenter(DataCenterResource.getDataCenter());
         waitTillProvisioned(newDatacenter.getRequestId());
         dataCenterId = newDatacenter.getId();
@@ -84,7 +82,7 @@ public class VolumeTest {
         serverId = newServer.getId();
 
         Volume volume = VolumeResource.getVolume();
-        volume.getProperties().setImage(imageId); //"Ubuntu-15.04-server-2015-07-01"
+        volume.getProperties().setImage(getImageId());
         Volume newVolume = profitbricksApi.getVolume().createVolume(dataCenterId, volume);
         assertNotNull(newVolume);
         waitTillProvisioned(newVolume.getRequestId());
@@ -96,7 +94,7 @@ public class VolumeTest {
     public static String getImageId() throws RestClientException, IOException {
         Images images = profitbricksApi.getImage().getAllImages();
         for (Image image : images.getItems()) {
-            if (image.getProperties().getName().toLowerCase().contains("ubuntu-16".toLowerCase()) && image.getProperties().getLocation().equals("us/las")
+            if (image.getProperties().getName().toLowerCase().contains("ubuntu".toLowerCase()) && image.getProperties().getLocation().equals("us/las")
                     && image.getProperties().getIsPublic() && image.getProperties().getImageType().equals("HDD")) {
                 return image.getId();
             }

--- a/src/test/java/com/profitbricks/rest/test/resource/VolumeResource.java
+++ b/src/test/java/com/profitbricks/rest/test/resource/VolumeResource.java
@@ -48,7 +48,7 @@ public class VolumeResource {
         if (volume == null) {
             volume = new Volume();
             volume.getProperties().setName("Java SDK Test");
-            volume.getProperties().setSize(2);
+            volume.getProperties().setSize(12);
             volume.getProperties().setBus(Bus.VIRTIO);
             volume.getProperties().setType("HDD");
             volume.getProperties().setAvailabilityZone(AvailabilityZone.ZONE_1);


### PR DESCRIPTION
There was some test failing when builind project with PROFITBRICKS_API_URL set to a VTE because of a hardcoded image name to "ubuntu-16". On the VTEs latest ubuntu version is <= 14. So I have used a more general image name "ubuntu" because there no reason to use a specific imahe for those test, as discused with Filex.

**In order to test this merge request:**
1. Checkout feature branch feature/VDC-5170
2. Set env variables:
    - PROFITBRICKS_API_URL
    - PROFITBRICKS_USERNAME
    - PROFITBRICKS_PASSWORD
3. Run "mvn clean install"

**Expected result:** 
All tests pass for public-api v4.